### PR TITLE
All playbooks in the tree are not visible unless user click in the reference viewer

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -219,7 +219,7 @@
           'hierarchical': {
             enabled: true,
             levelSeparation: 150,
-            nodeSpacing: 500,
+            nodeSpacing: 200,
             'sortMethod': 'directed',
             'direction': 'UD',
           }
@@ -258,12 +258,10 @@
         $window.open(url,'_blank');
       });
       setTimeout(() => {
-        if($scope.playbook_interconnection_vis_data.nodes.length === 1) {
-          $scope.playbook_interconnection_network.fit();
-        }
+        $scope.playbook_interconnection_network.redraw();
       }, 500);
       $scope.playbook_interconnection_network.on("stabilizationIterationsDone", function () {
-        $scope.playbook_interconnection_network.fit(); // Auto-adjusts view to avoid overlap
+        $scope.playbook_interconnection_network.setOptions({ physics: false }); // Stop physics after stabilization
         if($scope.playbook_interconnection_vis_data.nodes._data.length === 1) {
           $scope.playbook_interconnection_network.setOptions({ physics: { enabled: true } });
           $scope.playbook_interconnection_network.moveTo({


### PR DESCRIPTION
### Description :
1. All playbooks in the tree are not visible unless user click in the reference viewer
2. [Accelerate] Reference view tree changes its position when user refreshes the screen multiple times
3. Can we reduce distance between two playbooks in tree graph as user has to scroll a lot due to the distance

### Mantis:
1. https://mantis.fortinet.com/bug_view_page.php?bug_id=1136650
2. https://mantis.fortinet.com/bug_view_page.php?bug_id=1136653
3. https://mantis.fortinet.com/bug_view_page.php?bug_id=1136662